### PR TITLE
feat: support running the app via `docker compose …`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/.next
+**/.cache
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/charts
+**/docker-compose*
+**/compose*
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+**/build
+**/dist
+**/examples
+**/out
+LICENSE
+README.md

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
-BASE_URL=
+# fully qualified domain name for docker composition
+#
+BASE_URL=localhost
 
-MAIL_ADDRESS=
+# admin contact mail address for letsencrypt
+#
+MAIL_ADDRESS=mail@example.org

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+BASE_URL=
+
+MAIL_ADDRESS=

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,17 @@
+# https://github.com/vercel/next.js/blob/canary/examples/with-docker-compose/next-app/dev.Dockerfile
+
+FROM node:lts-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+#COPY src ./src
+#COPY public ./public
+#COPY next.config.js .
+COPY . .
+
+ENV NEXT_TELEMETRY_DISABLED 1
+
+CMD npm run dev

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,28 @@
+# https://github.com/vercel/next.js/blob/canary/examples/with-docker-compose/docker-compose.dev.yml
+
+version: '3'
+
+services:
+  medienhaus-dev-tools:
+    container_name: medienhaus-dev-tools
+    build:
+      context: .
+      dockerfile: dev.Dockerfile
+    #environment:
+    #  ENV_VARIABLE: ${ENV_VARIABLE}
+    #  NEXT_PUBLIC_ENV_VARIABLE: ${NEXT_PUBLIC_ENV_VARIABLE}
+    #env_file:
+    #  - .env
+    #volumes:
+    #  - ./medienhaus-dev-tools/src:/app/src
+    #  - ./medienhaus-dev-tools/public:/app/public
+    restart: unless-stopped
+    ports:
+      - 3000:3000
+    #networks:
+    #  - medienhaus-dev-tools
+
+#networks:
+#  medienhaus-dev-tools:
+#    driver: bridge
+#    external: true

--- a/docker-compose.example.websecure.yml
+++ b/docker-compose.example.websecure.yml
@@ -1,0 +1,85 @@
+# --------------------------------------------------------
+# `docker-compose.yml` for medienhaus/ develop environment
+# --------------------------------------------------------
+
+services:
+
+  # ------------------------------------------------------
+  # traefik
+  # ------------------------------------------------------
+
+  traefik:
+    image: traefik:latest
+    container_name: traefik
+    restart: unless-stopped
+    command:
+      #- "--log.level=DEBUG"
+      #- "--api.dashboard=true"
+      #- "--api.debug=true"
+      #- "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
+      - "--certificatesresolvers.myresolver.acme.email=${MAIL_ADDRESS}"
+      - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+    #labels:
+    #  traefik.enable: "true"
+    #  #traefik.http.routers.api.entrypoints: "web"
+    #  traefik.http.routers.api.entrypoints: "websecure"
+    #  traefik.http.routers.api.tls.certresolver: "myresolver"
+    #  traefik.http.routers.api.rule: "Host(`traefik.${BASE_URL}`)"
+    #  traefik.http.routers.api.service: "api@internal"
+    ports:
+      - "80:80"
+      #- "8080:8080"
+      - "443:443"
+      #- "8443:8443"
+    volumes:
+      - ./data/letsencrypt:/letsencrypt:rw
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+  # ------------------------------------------------------
+  # medienhaus-dev-tools
+  # ------------------------------------------------------
+
+  medienhaus-dev-tools:
+    build:
+      context: .
+      dockerfile: prod.Dockerfile
+    container_name: medienhaus-dev-tools
+    restart: unless-stopped
+    depends_on:
+      - traefik
+    labels:
+      traefik.enable: "true"
+      #traefik.http.routers.medienhaus-dev-tools.entrypoints: "web"
+      traefik.http.routers.medienhaus-dev-tools.entrypoints: "websecure"
+      traefik.http.routers.medienhaus-dev-tools.tls.certresolver: "myresolver"
+      traefik.http.routers.medienhaus-dev-tools.rule: "Host(`matrix-tools.${BASE_URL}`)"
+      traefik.http.services.medienhaus-dev-tools.loadbalancer.server.port: "3000"
+    #ports:
+    #  - "3000:3000"
+
+# ------------------------------------------------------
+# networks (example)
+# ------------------------------------------------------
+
+#networks:
+#  default:
+#    name: traefik
+#    driver: bridge
+#    external: true
+
+# ------------------------------------------------------
+# volumes (example)
+# ------------------------------------------------------
+
+#volumes:
+#  medienhaus-dev-tools--node_modules:
+#    driver: local
+#  medienhaus-dev-tools--.next:
+#    driver: local

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,85 @@
+# --------------------------------------------------------
+# `docker-compose.yml` for medienhaus/ develop environment
+# --------------------------------------------------------
+
+services:
+
+  # ------------------------------------------------------
+  # traefik
+  # ------------------------------------------------------
+
+  traefik:
+    image: traefik:latest
+    container_name: traefik
+    restart: unless-stopped
+    command:
+      #- "--log.level=DEBUG"
+      #- "--api.dashboard=true"
+      #- "--api.debug=true"
+      #- "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      #- "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      #- "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      #- "--entrypoints.websecure.address=:443"
+      #- "--certificatesresolvers.myresolver.acme.tlschallenge=true"
+      #- "--certificatesresolvers.myresolver.acme.email=${MAIL_ADDRESS}"
+      #- "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+    #labels:
+    #  traefik.enable: "true"
+    #  #traefik.http.routers.api.entrypoints: "web"
+    #  traefik.http.routers.api.entrypoints: "websecure"
+    #  traefik.http.routers.api.tls.certresolver: "myresolver"
+    #  traefik.http.routers.api.rule: "Host(`traefik.${BASE_URL}`)"
+    #  traefik.http.routers.api.service: "api@internal"
+    ports:
+      - "80:80"
+      #- "8080:8080"
+      #- "443:443"
+      #- "8443:8443"
+    volumes:
+      #- ./data/letsencrypt:/letsencrypt:rw
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+  # ------------------------------------------------------
+  # medienhaus-dev-tools
+  # ------------------------------------------------------
+
+  medienhaus-dev-tools:
+    build:
+      context: .
+      dockerfile: prod.Dockerfile
+    container_name: medienhaus-dev-tools
+    restart: unless-stopped
+    depends_on:
+      - traefik
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.medienhaus-dev-tools.entrypoints: "web"
+      #traefik.http.routers.medienhaus-dev-tools.entrypoints: "websecure"
+      #traefik.http.routers.medienhaus-dev-tools.tls.certresolver: "myresolver"
+      traefik.http.routers.medienhaus-dev-tools.rule: "Host(`matrix-tools.${BASE_URL}`)"
+      traefik.http.services.medienhaus-dev-tools.loadbalancer.server.port: "3000"
+    #ports:
+    #  - "3000:3000"
+
+# ------------------------------------------------------
+# networks (example)
+# ------------------------------------------------------
+
+#networks:
+#  default:
+#    name: traefik
+#    driver: bridge
+#    external: true
+
+# ------------------------------------------------------
+# volumes (example)
+# ------------------------------------------------------
+
+#volumes:
+#  medienhaus-dev-tools--node_modules:
+#    driver: local
+#  medienhaus-dev-tools--.next:
+#    driver: local

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,23 @@
+# https://github.com/vercel/next.js/blob/canary/examples/with-docker-compose/docker-compose.prod.yml
+
+version: '3'
+
+services:
+  medienhaus-dev-tools:
+    container_name: medienhaus-dev-tools
+    build:
+      context: .
+      dockerfile: prod.Dockerfile
+      #args:
+      #  ENV_VARIABLE: ${ENV_VARIABLE}
+      #  NEXT_PUBLIC_ENV_VARIABLE: ${NEXT_PUBLIC_ENV_VARIABLE}
+    restart: unless-stopped
+    ports:
+      - 3000:3000
+    #networks:
+    #  - medienhaus-dev-tools
+
+#networks:
+#  medienhaus-dev-tools:
+#    driver: bridge
+#    external: true

--- a/next.config.js
+++ b/next.config.js
@@ -15,5 +15,6 @@ module.exports = {
             allowAddingNewEmails: true,
         },
     },
+    output: 'standalone',
     webpack: WebpackConfig,
 };

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,0 +1,62 @@
+# https://github.com/vercel/next.js/blob/canary/examples/with-docker-compose/next-app/prod.Dockerfile
+
+FROM node:18-alpine AS base
+
+# Step 1. Rebuild the source code only when needed
+FROM base AS builder
+
+WORKDIR /app
+
+# Install dependencies based on the preferred package manager
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+#COPY src ./src
+#COPY public ./public
+#COPY next.config.js .
+COPY . .
+
+# Environment variables must be present at build time
+# https://github.com/vercel/next.js/discussions/14030
+ARG ENV_VARIABLE
+ENV ENV_VARIABLE=${ENV_VARIABLE}
+ARG NEXT_PUBLIC_ENV_VARIABLE
+ENV NEXT_PUBLIC_ENV_VARIABLE=${NEXT_PUBLIC_ENV_VARIABLE}
+
+# Uncomment the following line to disable telemetry at build time
+ENV NEXT_TELEMETRY_DISABLED 1
+
+# Build Next.js based on the preferred package manager
+RUN npm run build
+
+# Note: It is not necessary to add an intermediate step that does a full copy of `node_modules` here
+
+# Step 2. Production image, copy all the files and run next
+FROM base AS runner
+
+WORKDIR /app
+
+# Don't run production as root
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+USER nextjs
+
+COPY --from=builder /app/assets ./assets
+COPY --from=builder /app/pages ./pages
+COPY --from=builder /app/public ./public
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+# Environment variables must be redefined at run time
+ARG ENV_VARIABLE
+ENV ENV_VARIABLE=${ENV_VARIABLE}
+ARG NEXT_PUBLIC_ENV_VARIABLE
+ENV NEXT_PUBLIC_ENV_VARIABLE=${NEXT_PUBLIC_ENV_VARIABLE}
+
+# Uncomment the following line to disable telemetry at run time
+ENV NEXT_TELEMETRY_DISABLED 1
+
+CMD ["node", "server.js"]


### PR DESCRIPTION
### 🧃 The details

This pull-request adds support for running the application via `docker compose …`.

The respective docker-related files are not fine-tuned, but _work on my machine_, and are based on:

- https://github.com/vercel/next.js/tree/canary/examples/with-docker-compose#development
- https://github.com/vercel/next.js/tree/canary/examples/with-docker-compose#production

Feel free to test, and merge. 🐳

### 🧩 tl;dr for testing

#### For development via `docker-compose.dev.yml`
```
docker compose -f docker-compose.dev.yml build
```
```
docker compose -f docker-compose.dev.yml up
```

#### For production via `docker-compose.prod.yml`
```
docker compose -f docker-compose.prod.yml build
```
```
docker compose -f docker-compose.prod.yml up -d
```

### 🏗️ tl;dr for deployment

#### Configure `BASE_URL` and `MAIL_ADDRESS` in `.env` file
```
cp .env.example .env &&\
${VISUAL:-${EDITOR:-vim}} .env
```

#### For development with `traefik` in `http` context
```
docker compose -f docker-compose.example.yml up -d
```

#### For production with `traefik` in `https` context
```
docker compose -f docker-compose.example.websecure.yml up -d
```